### PR TITLE
OIEWP-895 Add geometry creation tools to px-map

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,7 +32,9 @@
     "px-theme": "^2.0.3",
     "leaflet": "^1.0.3",
     "leaflet.markercluster": "^1.0.3",
-    "leaflet-bing-tiles": "^1.0.0"
+    "leaflet-bing-tiles": "^1.0.0",
+    "leaflet-google-tiles": "https://github.com/ge-smallworld/leaflet-google-layer.git",
+    "leaflet.editable": "^1.0.0"
   },
   "devDependencies": {
     "px-clearfix-design": "^0.1.19",

--- a/px-map-behavior-layer-geojson.es6.js
+++ b/px-map-behavior-layer-geojson.es6.js
@@ -154,6 +154,18 @@
       });
       if(this.editable) {
         this.parentNode.elementInst.editTools = new L.Editable(this.parentNode.elementInst, {featuresLayer: geojsonLayer});
+        //Disable doubleclick zoom when drawing to prevent zooming when double clicking to end a line
+        this.parentNode.elementInst.editTools.addEventListener('editable:drawing:start', () => {
+          this.parentNode.elementInst.doubleClickZoom.disable();
+        });
+
+        this.parentNode.elementInst.editTools.addEventListener('editable:drawing:end', () => {
+          //0ms timeout to ensure that double clicking doesn't zoom when placing vertex and immeditaley finishing drawing
+          setTimeout(() => {
+            this.parentNode.elementInst.doubleClickZoom.enable();
+          },0);
+        });
+
       }
       return geojsonLayer;
     },

--- a/px-map-behavior-layer-geojson.es6.js
+++ b/px-map-behavior-layer-geojson.es6.js
@@ -153,7 +153,7 @@
         }
       });
       if(this.editable) {
-        this.parentNode.elementInst.editTools = new L.Editable(this.parentNode.elementInst, {editLayer: geojsonLayer});
+        this.parentNode.elementInst.editTools = new L.Editable(this.parentNode.elementInst, {featuresLayer: geojsonLayer});
       }
       return geojsonLayer;
     },

--- a/px-map-behavior-layer-geojson.es6.js
+++ b/px-map-behavior-layer-geojson.es6.js
@@ -36,6 +36,15 @@
       },
 
       /**
+       * Set to enable Leaflet.Editable
+       *
+       * @type {Boolean}
+       */
+      editable: {
+        type: Boolean,
+        value: false
+      },
+      /**
        * An object with settings that will be used to style each feature when
        * it is added to the map. The following options are available:
        *
@@ -143,7 +152,9 @@
           return this._getStyle(featureProperties, attributeProperties);
         }
       });
-
+      if(this.editable) {
+        this.parentNode.elementInst.editTools = new L.Editable(this.parentNode.elementInst, {editLayer: geojsonLayer});
+      }
       return geojsonLayer;
     },
 

--- a/px-map-leaflet-import.html
+++ b/px-map-leaflet-import.html
@@ -9,3 +9,5 @@
 
 <!-- EXTERNAL PLUGIN: Leaflet.markercluster, provides marker clustering functionality -->
 <script src="../leaflet.markercluster/dist/leaflet.markercluster.js"></script>
+<!-- EXTERNAL PLUGIN: Leaflet.Editable, provides geometry creation/manipulation functionality -->
+<script src="../leaflet.editable/src/Leaflet.Editable.js"></script>

--- a/test/px-map-layer-geojson-fixture.html
+++ b/test/px-map-layer-geojson-fixture.html
@@ -100,5 +100,15 @@
       </template>
     </test-fixture>
 
+    <test-fixture id="GeoJSONLayerFixtureEditable">
+      <template>
+        <px-map style="width:200px; height:200px;">
+          <px-map-layer-geojson data='{"type": "FeatureCollection", "features": [{"type": "Feature","properties": {},"geometry": {"type": "Point","coordinates": [0.11278152465820314,52.23526420307733]}}]}' editable>
+          </px-map-layer-geojson>
+        </px-map>
+      </template>
+    </test-fixture>
+
+
   </body>
 </html>

--- a/test/px-map-layer-geojson-tests.js
+++ b/test/px-map-layer-geojson-tests.js
@@ -260,6 +260,15 @@ function runCustomTests() {
       }, 10);
     });
 
+    it('enables Leaflet Editable when created if specified in the attribute', function() {
+      var map = fixture('GeoJSONLayerFixtureEditable');
+
+      // 0ms timeout needed to invoke assertion after the instance is created
+      setTimeout(function() {
+        assert.isDefined(map.elementInst.editTools);
+      },0);
+    });
+
   });
 
   describe('(events) px-map-layer-geojson', function () {


### PR DESCRIPTION
**Product:** sw-fibre-design-page
**Topic:** px-map
**Summary:** Added attribute to enable Leaflet.Editable on px-map-layer-geojson
**Release-Note:** Leaflet.Editable will be enabled when px-map-layer-geojson is created if specified in tag.
**Internal-Description:** Dependencies and imports updated, unit test added
**Documentation-Details:** N/A
**Gulp-Dist:** 
**Testing-Comments:** All unit tests passing
**Preflight:** N/A
