### PR TITLE
OIEWP-784 Provide tools for editing job objects

### DIFF
--- a/px-map-behavior-layer-geojson.es6.js
+++ b/px-map-behavior-layer-geojson.es6.js
@@ -107,6 +107,14 @@
        * - {String} `html`: [default=''] Custom HTML code to put inside the div element, empty by default. Ignored if divIcon is set to 'false'.
        * - {Array} `bgos`: [default=[0,0]] Optional relative position of the background, in pixels. Ignored if divIcon is set to 'false'.
        *
+       * When passing a SVG object to a divIcon, the following options are also available
+       *
+       * - {String} `stroke`: [default='none'] Stroke color
+       * - {String} `fillColor`: [default='black'] Fill color.
+       * - {Number} `weight`: [default=1] Stroke width in pixels.
+       * - {Number} `opacity`: [default=1] Stroke opacity.
+       * - {Number} `fillOpacity`: [default=1] Fill opacity.
+       *
        * @type {Object}
        */
       markerIconOptions: {
@@ -181,9 +189,16 @@
           let markerIcon
 
           if (iconOptions.divIcon) {
-            markerIcon = L.divIcon(iconOptions)
+            iconOptions.html = iconOptions.html || defaultMarkerIcon;
+            markerIcon = L.divIcon(iconOptions);
+            const SVG = markerIcon._icon.querySelector('object').contentDocument.querySelector('svg');
+            SVG.setAttribute('stroke',iconOptions.stroke);
+            SVG.setAttribute('fill',iconOptions.fillColor);
+            SVG.setAttribute('stroke-width',iconOptions.weight);
+            SVG.setAttribute('opacity',iconOptions.opacity);
+            SVG.setAttribute('fill-opacity',iconOptions.fillOpacity);
           } else {
-            iconOptions.iconUrl = options.markerIconOptions.iconSize || defaultMarkerIconURL;
+            iconOptions.iconUrl = iconOptions.iconSize || defaultMarkerIconURL;
             markerIcon = L.icon(iconOptions);
           }
 

--- a/px-map-behavior-layer-geojson.es6.js
+++ b/px-map-behavior-layer-geojson.es6.js
@@ -213,11 +213,7 @@
 
     _addEditableTools(leafletMap) {
       if(!leafletMap.editTools) {
-        if(this.sketch) {
-          leafletMap.editTools = new L.Editable(leafletMap, {featuresLayer: geojsonLayer});
-        } else {
-          leafletMap.editTools = new L.Editable(leafletMap);
-        }
+        leafletMap.editTools = new L.Editable(leafletMap);
         //Disable doubleclick zoom when drawing to prevent zooming when double clicking to end a line
         leafletMap.editTools.addEventListener('editable:drawing:start', () => {
           leafletMap.doubleClickZoom.disable();
@@ -240,11 +236,12 @@
             leafletMap.doubleClickZoom.enable();
           },0);
         });
-      } else {
-        if(this.sketch) {
-          leafletMap.editTools.featuresLayer = geojsonLayer;
-        }
       }
+
+      if(this.sketch) {
+        leafletMap.editTools.featuresLayer = geojsonLayer;
+      }
+
     },
 
     _getStyle(featureProperties, attributeProperties) {

--- a/px-map-behavior-layer-geojson.es6.js
+++ b/px-map-behavior-layer-geojson.es6.js
@@ -90,16 +90,27 @@
       },
 
       /**
-       * Leaflet.Icon options that can be set to use custom icons for drawing markers
+       * Leaflet.Icon options that can be set to use custom icons for drawing markers.
+       * The following options are available:
        *
+       * - {Boolean} `divIcon`: [default=false] Set to use L.divIcon instead of L.Icon.
+       * - {String} `iconUrl`: [default=null] The URL to the icon image (absolute or relative to your script path). Ignored if divIcon is set to 'true'.
+       * - {String} `iconRetinaUrl`: [default=null] The URL to a retina sized version of the icon image (absolute or relative to your script path). Used for Retina screen devices. Ignored if divIcon is set to 'true'.
+       * - {Array} `iconSize`: [default=[16,16]] 	Size of the icon image in pixels.
+       * - {Array} `iconAnchor`: [default=[8,8]] The coordinates of the "tip" of the icon (relative to its top left corner). The icon will be aligned so that this point is at the marker's geographical location. Centered by default if size is specified, also can be set in CSS with negative margins.
+       * - {Array} `popupAnchor`: [default=null] The coordinates of the point from which popups will "open", relative to the icon anchor.
+       * - {String} `shadowUrl`: [default=null] The URL to the icon shadow image. If not specified, no shadow image will be created. Ignored if divIcon is set to 'true'.
+       * - {String} `shadowRetinaUrl`: [default=null] Ignored if divIcon is set to 'true'.
+       * - {Array} `shadowSize`: [default=null] Size of the shadow image in pixels. Ignored if divIcon is set to 'true'.
+       * - {Array} `shadowAnchor`: [default=null] The coordinates of the "tip" of the shadow (relative to its top left corner) (the same as iconAnchor if not specified). Ignored if divIcon is set to 'true'.
+       * - {String} `className`: [default=''] A custom class name to assign to both icon and shadow images. Empty by default.
+       * - {String} `html`: [default=''] Custom HTML code to put inside the div element, empty by default. Ignored if divIcon is set to 'false'.
+       * - {Array} `bgos`: [default=[0,0]] Optional relative position of the background, in pixels. Ignored if divIcon is set to 'false'.
        *
        * @type {Object}
        */
       markerIconOptions: {
         type: Object,
-        value: function() {
-          return {};
-        },
         observer: 'shouldUpdateInst'
       },
       /**
@@ -166,9 +177,15 @@
           const iconOptions = options.markerIconOptions;
           iconOptions.iconSize = options.markerIconOptions.iconSize || [16, 16];
           iconOptions.iconAnchor = options.markerIconOptions.iconAnchor || [8, 8];
-          iconOptions.iconUrl = options.markerIconOptions.iconSize || defaultMarkerIconURL;
 
-          const markerIcon = L.icon(iconOptions);
+          let markerIcon
+
+          if (iconOptions.divIcon) {
+            markerIcon = L.divIcon(iconOptions)
+          } else {
+            iconOptions.iconUrl = options.markerIconOptions.iconSize || defaultMarkerIconURL;
+            markerIcon = L.icon(iconOptions);
+          }
 
           return new L.Marker(latlng, {icon: markerIcon});
         },

--- a/px-map-behavior-layer-geojson.es6.js
+++ b/px-map-behavior-layer-geojson.es6.js
@@ -107,14 +107,6 @@
        * - {String} `html`: [default=''] Custom HTML code to put inside the div element, empty by default. Ignored if divIcon is set to 'false'.
        * - {Array} `bgos`: [default=[0,0]] Optional relative position of the background, in pixels. Ignored if divIcon is set to 'false'.
        *
-       * When passing a SVG object to a divIcon, the following options are also available
-       *
-       * - {String} `stroke`: [default='none'] Stroke color
-       * - {String} `fillColor`: [default='black'] Fill color.
-       * - {Number} `weight`: [default=1] Stroke width in pixels.
-       * - {Number} `opacity`: [default=1] Stroke opacity.
-       * - {Number} `fillOpacity`: [default=1] Fill opacity.
-       *
        * @type {Object}
        */
       markerIconOptions: {
@@ -186,17 +178,11 @@
           iconOptions.iconSize = options.markerIconOptions.iconSize || [16, 16];
           iconOptions.iconAnchor = options.markerIconOptions.iconAnchor || [8, 8];
 
-          let markerIcon
+          let markerIcon;
 
           if (iconOptions.divIcon) {
             iconOptions.html = iconOptions.html || defaultMarkerIcon;
             markerIcon = L.divIcon(iconOptions);
-            const SVG = markerIcon._icon.querySelector('object').contentDocument.querySelector('svg');
-            SVG.setAttribute('stroke',iconOptions.stroke);
-            SVG.setAttribute('fill',iconOptions.fillColor);
-            SVG.setAttribute('stroke-width',iconOptions.weight);
-            SVG.setAttribute('opacity',iconOptions.opacity);
-            SVG.setAttribute('fill-opacity',iconOptions.fillOpacity);
           } else {
             iconOptions.iconUrl = iconOptions.iconSize || defaultMarkerIconURL;
             markerIcon = L.icon(iconOptions);

--- a/px-map-behavior-layer-geojson.es6.js
+++ b/px-map-behavior-layer-geojson.es6.js
@@ -184,7 +184,7 @@
             iconOptions.html = iconOptions.html || defaultMarkerIcon;
             markerIcon = L.divIcon(iconOptions);
           } else {
-            iconOptions.iconUrl = iconOptions.iconSize || defaultMarkerIconURL;
+            iconOptions.iconUrl = iconOptions.iconUrl || defaultMarkerIconURL;
             markerIcon = L.icon(iconOptions);
           }
 
@@ -206,7 +206,7 @@
 
       if(this.editable) {
         if(!this.parentNode.elementInst.editTools) {
-          if(this.sketchLayer) {
+          if(this.sketch) {
             this.parentNode.elementInst.editTools = new L.Editable(this.parentNode.elementInst, {featuresLayer: geojsonLayer});
           } else {
             this.parentNode.elementInst.editTools = new L.Editable(this.parentNode.elementInst);
@@ -233,7 +233,7 @@
               this.parentNode.elementInst.doubleClickZoom.enable();
             },0);
           });
-        } else if(this.sketchLayer) {
+        } else if(this.sketch) {
           this.parentNode.elementInst.editTools.featuresLayer = geojsonLayer;
         }
       }
@@ -325,7 +325,7 @@
           const markerIcon = L.icon(iconOptions);
 
           return new L.Marker(latlng, {icon: markerIcon});
-        }
+        };
 
         this.elementInst.clearLayers();
         this.elementInst.addData(nextOptions.data);

--- a/px-map-behavior-layer-geojson.es6.js
+++ b/px-map-behavior-layer-geojson.es6.js
@@ -67,8 +67,8 @@
        *
        * @type {Object}
        */
-      featureStyle: {
-        type: Object,
+      featureSVG: {
+        type: String,
         observer: 'shouldUpdateInst'
       },
 
@@ -135,11 +135,19 @@
 
       const geojsonLayer = L.geoJson(options.data, {
         pointToLayer: (feature, latlng) => {
-          const featureProperties = feature.properties.style || {};
-          const attributeProperties = options.featureStyle;
-          const style = this._getStyle(feature, featureProperties, attributeProperties);
+          const featureSVG = feature.properties.svg || {};
+          const attributeSVG = options.featureSVG;
+          const SVG = this._getSVG(feature, featureSVG, attributeSVG);
 
-          return new L.CircleMarker(latlng, style);
+          var SVGURL = "data:image/svg+xml;base64," + btoa(SVG);
+
+          var SVGIcon = L.icon( {
+            iconUrl: SVGURL,
+            iconSize: [300, 300],
+            iconAnchor: [150, 120]
+          } );
+
+          return new L.Marker(latlng, {icon: SVGIcon});
         },
 
         onEachFeature: (feature, layer) => {
@@ -152,6 +160,7 @@
 
           return this._getStyle(featureProperties, styleAttributeProperties);
         }
+
       });
       if(this.editable) {
         if (!this.parentNode.elementInst.editTools) {
@@ -175,15 +184,19 @@
       return geojsonLayer;
     },
 
-    _getStyle(featureProperties, attributeProperties) {
-      return {
-        radius: featureProperties.radius           || attributeProperties.radius      || 5,
-        color: featureProperties.color             || attributeProperties.color       || '#3E87E8', //primary-blue,
-        fillColor: featureProperties.fillColor     || attributeProperties.fillColor   || '#88BDE6', //$dv-light-blue
-        weight: featureProperties.weight           || attributeProperties.weight      || 2,
-        opacity: featureProperties.opacity         || attributeProperties.opacity     || 1,
-        fillOpacity: featureProperties.fillOpacity || attributeProperties.fillOpacity || 0.4
-      };
+    _getSVG(featureProperties, attributeProperties) {
+      // return {
+      //   radius: featureProperties.radius           || attributeProperties.radius      || 5,
+      //   color: featureProperties.color             || attributeProperties.color       || '#3E87E8', //primary-blue,
+      //   fillColor: featureProperties.fillColor     || attributeProperties.fillColor   || '#88BDE6', //$dv-light-blue
+      //   weight: featureProperties.weight           || attributeProperties.weight      || 2,
+      //   opacity: featureProperties.opacity         || attributeProperties.opacity     || 1,
+      //   fillOpacity: featureProperties.fillOpacity || attributeProperties.fillOpacity || 0.4
+      // };
+
+      return '<svg xmlns="http://www.w3.org/2000/svg" version="1.1"  height="300" width="200"><polygon points="100,10, 40,198, 190,78 10,78, 160,198," style="fill:lime;stroke-opacity:1;stroke:purple;stroke-width:5;fill-rule:evenodd;" /></svg>';
+      //featureProperties || attributeProperties ||
+
     },
 
     _bindFeaturePopups() {

--- a/px-map-behavior-layer-geojson.es6.js
+++ b/px-map-behavior-layer-geojson.es6.js
@@ -205,40 +205,46 @@
       });
 
       if(this.editable) {
-        if(!this.parentNode.elementInst.editTools) {
-          if(this.sketch) {
-            this.parentNode.elementInst.editTools = new L.Editable(this.parentNode.elementInst, {featuresLayer: geojsonLayer});
-          } else {
-            this.parentNode.elementInst.editTools = new L.Editable(this.parentNode.elementInst);
-          }
-          //Disable doubleclick zoom when drawing to prevent zooming when double clicking to end a line
-          this.parentNode.elementInst.editTools.addEventListener('editable:drawing:start', () => {
-            this.parentNode.elementInst.doubleClickZoom.disable();
-          });
-
-          this.parentNode.elementInst.editTools.addEventListener('editable:drawing:end', () => {
-            //0ms timeout to ensure that double clicking doesn't zoom when placing vertex and immeditaley finishing drawing
-            setTimeout(() => {
-              this.parentNode.elementInst.doubleClickZoom.enable();
-            },0);
-          });
-
-          this.parentNode.elementInst.editTools.addEventListener('editable:dragstart', () => {
-            this.parentNode.elementInst.doubleClickZoom.disable();
-          });
-
-          this.parentNode.elementInst.editTools.addEventListener('editable:dragend', () => {
-            //0ms timeout to ensure that double clicking doesn't zoom when placing vertex and immeditaley finishing drawing
-            setTimeout(() => {
-              this.parentNode.elementInst.doubleClickZoom.enable();
-            },0);
-          });
-        } else if(this.sketch) {
-          this.parentNode.elementInst.editTools.featuresLayer = geojsonLayer;
-        }
+        this._addEditableTools(this.parentNode.elementInst);
       }
 
       return geojsonLayer;
+    },
+
+    _addEditableTools(leafletMap) {
+      if(!leafletMap.editTools) {
+        if(this.sketch) {
+          leafletMap.editTools = new L.Editable(leafletMap, {featuresLayer: geojsonLayer});
+        } else {
+          leafletMap.editTools = new L.Editable(leafletMap);
+        }
+        //Disable doubleclick zoom when drawing to prevent zooming when double clicking to end a line
+        leafletMap.editTools.addEventListener('editable:drawing:start', () => {
+          leafletMap.doubleClickZoom.disable();
+        });
+
+        leafletMap.editTools.addEventListener('editable:drawing:end', () => {
+          //0ms timeout to ensure that double clicking doesn't zoom when placing vertex and immeditaley finishing drawing
+          setTimeout(() => {
+            leafletMap.doubleClickZoom.enable();
+          },0);
+        });
+
+        leafletMap.editTools.addEventListener('editable:dragstart', () => {
+          leafletMap.doubleClickZoom.disable();
+        });
+
+        leafletMap.editTools.addEventListener('editable:dragend', () => {
+          //0ms timeout to ensure that double clicking doesn't zoom when placing vertex and immeditaley finishing drawing
+          setTimeout(() => {
+            leafletMap.doubleClickZoom.enable();
+          },0);
+        });
+      } else {
+        if(this.sketch) {
+          leafletMap.editTools.featuresLayer = geojsonLayer;
+        }
+      }
     },
 
     _getStyle(featureProperties, attributeProperties) {

--- a/px-map-behavior-layer-geojson.es6.js
+++ b/px-map-behavior-layer-geojson.es6.js
@@ -99,7 +99,7 @@
        */
       featuresSvg: {
         type: String
-      }
+      },
 
       /**
        * Leaflet.Icon options that can be set to use custom icons for drawing markers
@@ -111,7 +111,7 @@
        */
       markerIconOptions: {
         type: Object,
-        value function() {
+        value: function() {
           return {};
         }
       }
@@ -169,7 +169,7 @@
 
           var SVGURL = "data:image/svg+xml;base64," + btoa(SVG);
 
-          iconOptions = options.markerIconOptions;
+          const iconOptions = options.markerIconOptions;
 
           if (!iconOptions.iconUrl) {
             iconOptions.iconUrl = SVGURL;
@@ -189,7 +189,7 @@
           const featureProperties = feature.properties.style || {};
           const attributeProperties = this.getInstOptions().featureStyle;
 
-          return this._getVG(featureProperties, attributeProperties);
+          return this._getStyle(featureProperties, attributeProperties);
         }
 
       });
@@ -216,8 +216,19 @@
       return geojsonLayer;
     },
 
+    _getStyle(featureStyle, attributeStyle) {
+      return return {
+        radius: featureProperties.radius           || attributeProperties.radius      || 5,
+        color: featureProperties.color             || attributeProperties.color       || '#3E87E8', //primary-blue,
+        fillColor: featureProperties.fillColor     || attributeProperties.fillColor   || '#88BDE6', //$dv-light-blue
+        weight: featureProperties.weight           || attributeProperties.weight      || 2,
+        opacity: featureProperties.opacity         || attributeProperties.opacity     || 1,
+        fillOpacity: featureProperties.fillOpacity || attributeProperties.fillOpacity || 0.4
+      };
+    },
+
     _getSVG(featureSVG, attributeSVG) {
-      return featureSVG || attributeSVG ||'<svg xmlns="http://www.w3.org/2000/svg" version="1.1"  height="16" width="16"><circle cx="8" cy="8" r="6" stroke="#3E87E8" stroke-width="3" fill="#88BDE6" /></svg>';
+      return featureSVG || attributeSVG ||'<svg xmlns="http://www.w3.org/2000/svg" version="1.1"  height="16" width="16"><circle cx="8" cy="8" r="6" stroke="#3E87E8" stroke-width="3" fill="#88BDE6" fill-opacity="0.4"/></svg>';
     },
 
     _bindFeaturePopups() {

--- a/test/px-map-layer-geojson-fixture.html
+++ b/test/px-map-layer-geojson-fixture.html
@@ -30,7 +30,7 @@
     <test-fixture id="GeoJSONLayerFixture">
       <template>
         <px-map style="width:200px; height:200px;">
-          <px-map-layer-geojson data='{"type": "FeatureCollection", "features": [{"type": "Feature","properties": {},"geometry": {"type": "Point","coordinates": [0.11278152465820314,52.23526420307733]}}]}'
+          <px-map-layer-geojson data='{"type": "FeatureCollection", "features": [{"type": "Feature","properties": {},"geometry": {"type": "LineString","coordinates": [[0.11278152465820314,52.23526420307733],[0,0]]}}]}'
               feature-style='{"color": "green"}'
               show-feature-properties>
           </px-map-layer-geojson>
@@ -49,7 +49,7 @@
     <test-fixture id="GeoJSONLayerFixtureOnlyData">
       <template>
         <px-map style="width:200px; height:200px;" lat="52.23526420307733" lng="0.11278152465820314" zoom="2">
-          <px-map-layer-geojson data='{"type": "FeatureCollection", "features": [{"type": "Feature","properties": {},"geometry": {"type": "Point","coordinates": [0.11278152465820314,52.23526420307733]}}]}'></px-map-layer-geojson>
+          <px-map-layer-geojson data='{"type": "FeatureCollection", "features": [{"type": "Feature","properties": {},"geometry": {"type": "LineString","coordinates": [[0.11278152465820314,52.23526420307733],[0,0]]}}]}'></px-map-layer-geojson>
         </px-map>
       </template>
     </test-fixture>
@@ -57,7 +57,7 @@
     <test-fixture id="GeoJSONLayerFixtureFeatureStyles">
       <template>
         <px-map style="width:200px; height:200px;">
-          <px-map-layer-geojson data='{"type": "FeatureCollection", "features": [{"type": "Feature","properties": {"style": {"color": "#ff0000"}},"geometry": {"type": "Point","coordinates": [0.11278152465820314,52.23526420307733]}}]}'></px-map-layer-geojson>
+          <px-map-layer-geojson data='{"type": "FeatureCollection", "features": [{"type": "Feature","properties": {"style": {"color": "#ff0000"}},"geometry": {"type": "LineString","coordinates": [[0.11278152465820314,52.23526420307733],[0,0]]}}]}'></px-map-layer-geojson>
         </px-map>
       </template>
     </test-fixture>

--- a/test/px-map-layer-geojson-tests.js
+++ b/test/px-map-layer-geojson-tests.js
@@ -42,7 +42,7 @@ function runCustomTests() {
 
       setTimeout(function(){
         pxMap.eachLayer(function(layer) {
-          if (layer instanceof L.CircleMarker) {
+          if (layer instanceof L.Polyline) {
             layers++;
           }
         });
@@ -63,7 +63,7 @@ function runCustomTests() {
     });
 
     it('adds data to the map through attributes (via `data=`)', function(done) {
-      var dataObject = {"type": "FeatureCollection", "features": [{"type": "Feature","properties": {},"geometry": {"type": "Point","coordinates": [0.11278152465820314,52.23526420307733]}}]};
+      var dataObject = {"type": "FeatureCollection", "features": [{"type": "Feature","properties": {},"geometry": {"type": "LineString","coordinates": [[0.11278152465820314,52.23526420307733],[0,0]]}}]};
 
       setTimeout(function(){
         var geoJSONLayer = geoJSONLayerFixture.querySelector('px-map-layer-geojson');
@@ -148,7 +148,7 @@ function runCustomTests() {
     });
 
     it('styles features correctly through attributes (via `feature-style=`)', function(done) {
-      var featureStyles = {'color': 'green'};
+      var featureStyles = {color: 'green'};
 
       setTimeout(function(){
         var geoJSONLayer = geoJSONLayerFixture.querySelector('px-map-layer-geojson');
@@ -249,13 +249,13 @@ function runCustomTests() {
       }, 10);
     });
 
-    it('creates a circle marker from Point features', function(done) {
+    it('creates a marker from Point features', function(done) {
       setTimeout(function() {
         var geoJSONLayer = withPopupFixture.querySelector('px-map-layer-geojson');
         var geoJSONLayerInstance = geoJSONLayer.elementInst;
         var drawnLayer = geoJSONLayerInstance.getLayers()[0];
 
-        expect(drawnLayer).to.be.an.instanceof(L.CircleMarker);
+        expect(drawnLayer).to.be.an.instanceof(L.Marker);
         done();
       }, 10);
     });


### PR DESCRIPTION
**Product:** px-map
**Topic:** Leaflet Editable
**Summary:** Change how L.Editable is implemented and change from using circleMarkers to Markers
**Release-Note:** The geoJSON layer now creates Leaflet Markers instead of CircleMarkers, with the option of either using Leaflet Icons or DivIcons to style it. A new boolean property `sketch` has also been added, which will specify that layer as the layer where drawn features will be stored. 
**Internal-Description:** Changes made for story https://devcloud.swcoe.ge.com/jira03/browse/OIEWP-784.
**Documentation-Details:** N/A
**Gulp-Dist:** N/A
**Testing-Comments:** 
**Preflight:** N/A

