### PR TITLE
Fix bug when enabling editable with sketch

### DIFF
--- a/px-map-behavior-layer-geojson.es6.js
+++ b/px-map-behavior-layer-geojson.es6.js
@@ -205,13 +205,13 @@
       });
 
       if(this.editable) {
-        this._addEditableTools(this.parentNode.elementInst);
+        this._addEditableTools(this.parentNode.elementInst, geojsonLayer);
       }
 
       return geojsonLayer;
     },
 
-    _addEditableTools(leafletMap) {
+    _addEditableTools(leafletMap, geojsonLayer) {
       if(!leafletMap.editTools) {
         leafletMap.editTools = new L.Editable(leafletMap);
         //Disable doubleclick zoom when drawing to prevent zooming when double clicking to end a line


### PR DESCRIPTION
**Product:** px-map
**Topic:** Bugfix
**Summary:** Fix bug when enabling editable with sketch
**Release-Note:** Fix error when attempting to create an editable Layer with the sketch tag.
**Internal-Description:** 
**Documentation-Details:** N/A
**Gulp-Dist:** N/A
**Testing-Comments:** 
**Preflight:** N/A