### PR TITLE
Prevent highlighting feature at wrong zoom level.

### DIFF
--- a/px-map-behavior-layer-IMS.es6.js
+++ b/px-map-behavior-layer-IMS.es6.js
@@ -258,6 +258,10 @@
       if (!this.featureCollection) {
         return;
       }
+      
+      if (this.parentNode.elementInst.getZoom() < this._getLayerStartingZoomValue()) {
+        return;
+      }
 
       this.elementInst.clearLayers();
 
@@ -699,6 +703,11 @@
      */
     highlightFeature(featureId, styleOptions) {
       let done = false;
+
+      if (this.parentNode.elementInst.getZoom() < this._getLayerStartingZoomValue()) {
+          return done;
+      }
+
       const data = this._featureMap[featureId];
 
       if (data) {
@@ -719,6 +728,7 @@
           done = true;
         }
       }
+
       return done;
     },
 


### PR DESCRIPTION
Updated highlightFeature() and _redrawIMSLayer() to not render if the features are not visible at the current zoom level.
To check:
1. Select a service point and zoom out until they are not shown.
2. Select another type of object
Expect the selection to update without redrawing service points.
