### PR TITLE
OIEWP-1091 Fix selection order to match the rendering order on the map

### DIFF
--- a/px-map-behavior-layer-IMS.es6.js
+++ b/px-map-behavior-layer-IMS.es6.js
@@ -1311,12 +1311,22 @@
         maxX: x,
         maxY: y
       });
-      // Note - only returns first match
+
       if (points.length) {
-          this.fire('px-map-layer-geojson-feature-tapped', {
-            feature: points[0].feature,
-            layerId: this.id
-          });
+        // Find the closest point to the click event
+        let result;
+        let minDist = Infinity;
+        points.forEach(point => {
+          const dist = point.pixelPoint.distanceTo(conPoint);
+          if (dist < minDist) {
+            minDist = dist;
+            result = point.feature;
+          }
+        });
+        this.fire('px-map-layer-geojson-feature-tapped', {
+          feature: result,
+          layerId: this.id
+        });
       }
     },
     /**


### PR DESCRIPTION
Fixes the selection order to match the rendering order of the IMS layers.
Sorted the click handlers for each icon canvas, stored on the map, by the z index of the layer pane.
'px-map-layer-geojson-feature-tapped' events are now fired in ascending z index order. Events for points rendered on top will be fired last.
The connectivity test app still handles all tapped events and aborts previous requests to handle the last - the one expected by the user.
Updated _handleIconCanvasClicked() to return the closest point the event click rather than the first in the search results.
Updated _drawIcon() to use the devicePixelRatio so image drawn using drawImage() are sharp on high dpi screens.
Tested using the connectivity test app:
1. Refreshed the connectivity test app page.
2. Selected near the edge of one of the transformer icons at the Cortland substation.
-> Transformer is selected rather than anything underneath the icon.
3. Selected near the edge of any breaker drawn on top at the substation.
-> Breaker is selected as expected.
