### PR TITLE
OIEWP-1074 Update to use ge-smallworld/rbush fork

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,8 @@
     "leaflet.markercluster": "1.0.3",
     "leaflet-bing-tiles": "^1.0.0",
     "leaflet-google-tiles": "https://github.com/ge-smallworld/leaflet-google-layer.git",
-    "leaflet.editable": "^1.0.0"
+    "leaflet.editable": "^1.0.0",
+    "rbush": "https://github.com/ge-smallworld/rbush.git#master"
   },
   "devDependencies": {
     "px-clearfix-design": "^0.1.19",

--- a/px-map-rbush.html
+++ b/px-map-rbush.html
@@ -1,2 +1,2 @@
 <!-- Extends the following behaviors -->
-<script src="https://unpkg.com/rbush@2.0.1/rbush.min.js"></script>
+<script src="../rbush/dist/rbush.min.js"></script>


### PR DESCRIPTION
Update bower file to include rbush fork from ge-smallworld org.
This fork includes the browser versions so the source is no longer loaded from the CDN link which was causing problems with the proxy.
